### PR TITLE
Fix Conan Test image

### DIFF
--- a/conan_tests/Dockerfile
+++ b/conan_tests/Dockerfile
@@ -25,8 +25,8 @@ RUN sudo apt-get update \
     pkg-config \
     && sudo rm -rf /var/lib/apt/lists/* \
     && sudo pip install --upgrade pip \
-    && cd /tmp && wget https://bootstrap.pypa.io/get-pip.py \
-    && sudo python3 get-pip.py \
+    && wget --no-check-certificate --quiet -O /tmp/get-pip.py https://bootstrap.pypa.io/get-pip.py \
+    && sudo python3 /tmp/get-pip.py \
     && sudo pip install "virtualenv<20.0.0" \
     && pip3 install PyGithub \
     && pip3 install meson


### PR DESCRIPTION
Python3 was not able to find get-pip.py.

My guess: cd only worked for wget, on next command it returned to the old path.

related to https://github.com/conan-io/conan-docker-tools/pull/194